### PR TITLE
update gradle 8.7, android gradle plugin 8.4.1

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -55,7 +55,7 @@ android {
       signingConfig = signingConfigs.getByName("release")
     }
   }
-  packagingOptions {
+  packaging {
     resources {
       excludes += "/META-INF/{AL2.0,LGPL2.1}"
     }

--- a/build-logic/convention/src/main/java/com/tatsuki/inappbilling/AndroidCompose.kt
+++ b/build-logic/convention/src/main/java/com/tatsuki/inappbilling/AndroidCompose.kt
@@ -26,7 +26,7 @@ import org.gradle.kotlin.dsl.dependencies
  * Configure Compose-specific options
  */
 internal fun Project.configureAndroidCompose(
-  commonExtension: CommonExtension<*, *, * ,*>,
+  commonExtension: CommonExtension<*, *, * ,*, *, *>,
 ) {
   commonExtension.apply {
     buildFeatures {

--- a/build-logic/convention/src/main/java/com/tatsuki/inappbilling/KotlinAndroid.kt
+++ b/build-logic/convention/src/main/java/com/tatsuki/inappbilling/KotlinAndroid.kt
@@ -28,7 +28,7 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
  * Configure base Kotlin with Android options
  */
 internal fun Project.configureKotlinAndroid(
-  commonExtension: CommonExtension<*, *, *, *>,
+  commonExtension: CommonExtension<*, *, *, *, *, *>,
 ) {
     commonExtension.apply {
       compileSdk = 34

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 android-billingclient = "6.0.1"
-android-gradke-plugin = "8.0.2"
+android-gradke-plugin = "8.4.1"
 androidx-activity = "1.7.2"
 androidx-fragment = "1.6.1"
 # BOM to library version mapping

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Wed Sep 06 11:35:02 JST 2023
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **更新**
  - Android Gradle プラグインのバージョンを `8.0.2` から `8.4.1` にアップデートしました。
  - Gradle のバージョンを `8.0` から `8.7` にアップデートしました。

- **内部改善**
  - `packagingOptions` ブロックを `packaging` ブロックにリネームしました（機能に影響なし）。
  - `configureAndroidCompose` 関数に追加の型パラメータを導入しました。
  - `configureKotlinAndroid` 関数に追加の型パラメータを導入しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->